### PR TITLE
corrects example library implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,15 @@ functionality to an existing Go application. For example:
 
     import (
             "log"
+            "time"
+            "net"
+            "os"
 
             "github.com/ibm-security-innovation/crosscoap"
     )
 
     func main() {
+            timeout := time.Duration(10)
             appLog := log.New(os.Stderr, "", log.LstdFlags)
             udpAddr, err := net.ResolveUDPAddr("udp", "0.0.0.0:5683")
             if err != nil {
@@ -111,10 +115,10 @@ functionality to an existing Go application. For example:
                     errorLog.Fatalln("Can't listen on UDP")
             }
             defer udpListener.Close()
-            p := crosscoap.COAPProxy{
+            p := crosscoap.Proxy{
                     Listener:   udpListener,
                     BackendURL: "http://127.0.0.1:8000/",
-                    Timeout:    10 * time.Second,
+                    Timeout:    &timeout,
                     AccessLog:  appLog,
                     ErrorLog:   appLog,
             }

--- a/README.md
+++ b/README.md
@@ -96,11 +96,15 @@ functionality to an existing Go application. For example:
 
     import (
             "log"
+            "time"
+            "net"
+            "os"
 
             "github.com/ibm-security-innovation/crosscoap"
     )
 
     func main() {
+            timeout := time.Duration(10 * time.Second)
             appLog := log.New(os.Stderr, "", log.LstdFlags)
             udpAddr, err := net.ResolveUDPAddr("udp", "0.0.0.0:5683")
             if err != nil {
@@ -111,10 +115,10 @@ functionality to an existing Go application. For example:
                     errorLog.Fatalln("Can't listen on UDP")
             }
             defer udpListener.Close()
-            p := crosscoap.COAPProxy{
+            p := crosscoap.Proxy{
                     Listener:   udpListener,
                     BackendURL: "http://127.0.0.1:8000/",
-                    Timeout:    10 * time.Second,
+                    Timeout:    &timeout,
                     AccessLog:  appLog,
                     ErrorLog:   appLog,
             }

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ functionality to an existing Go application. For example:
     )
 
     func main() {
-            timeout := time.Duration(10)
+            timeout := time.Duration(10 * time.Second)
             appLog := log.New(os.Stderr, "", log.LstdFlags)
             udpAddr, err := net.ResolveUDPAddr("udp", "0.0.0.0:5683")
             if err != nil {

--- a/crosscoap.go
+++ b/crosscoap.go
@@ -9,7 +9,7 @@
 //
 //     import (
 //             "log"
-//	       "net"
+//	           "net"
 //             "os"
 //             "time"
 //
@@ -17,7 +17,7 @@
 //     )
 //
 //     func main() {
-//	       timeout := time.Duration(10)
+//             timeout := time.Duration(10 * time.Second)
 //             appLog := log.New(os.Stderr, "[example] ", log.LstdFlags)
 //             udpAddr, err := net.ResolveUDPAddr("udp", "0.0.0.0:5683")
 //             if err != nil {

--- a/crosscoap.go
+++ b/crosscoap.go
@@ -9,15 +9,15 @@
 //
 //     import (
 //             "log"
-//						 "net"
-//						 "os"
-//						 "time"
+//	       "net"
+//             "os"
+//             "time"
 //
 //             "github.com/ibm-security-innovation/crosscoap"
 //     )
 //
 //     func main() {
-//						 timeout := time.Duration(10)
+//	       timeout := time.Duration(10)
 //             appLog := log.New(os.Stderr, "[example] ", log.LstdFlags)
 //             udpAddr, err := net.ResolveUDPAddr("udp", "0.0.0.0:5683")
 //             if err != nil {
@@ -28,7 +28,7 @@
 //                     errorLog.Fatalln("Can't listen on UDP")
 //             }
 //             defer udpListener.Close()
-//             p := crosscoap.COAPProxy{
+//             p := crosscoap.Proxy{
 //                     Listener:   udpListener,
 //                     BackendURL: "http://127.0.0.1:8000/",
 //                     Timeout:    &timeout,

--- a/crosscoap.go
+++ b/crosscoap.go
@@ -9,11 +9,15 @@
 //
 //     import (
 //             "log"
+//						 "net"
+//						 "os"
+//						 "time"
 //
 //             "github.com/ibm-security-innovation/crosscoap"
 //     )
 //
 //     func main() {
+//						 timeout := time.Duration(10)
 //             appLog := log.New(os.Stderr, "[example] ", log.LstdFlags)
 //             udpAddr, err := net.ResolveUDPAddr("udp", "0.0.0.0:5683")
 //             if err != nil {
@@ -27,7 +31,7 @@
 //             p := crosscoap.COAPProxy{
 //                     Listener:   udpListener,
 //                     BackendURL: "http://127.0.0.1:8000/",
-//                     Timeout:    10 * time.Second,
+//                     Timeout:    &timeout,
 //                     AccessLog:  appLog,
 //                     ErrorLog:   appLog,
 //             }

--- a/crosscoap.go
+++ b/crosscoap.go
@@ -9,11 +9,15 @@
 //
 //     import (
 //             "log"
+//	           "net"
+//             "os"
+//             "time"
 //
 //             "github.com/ibm-security-innovation/crosscoap"
 //     )
 //
 //     func main() {
+//             timeout := time.Duration(10 * time.Second)
 //             appLog := log.New(os.Stderr, "[example] ", log.LstdFlags)
 //             udpAddr, err := net.ResolveUDPAddr("udp", "0.0.0.0:5683")
 //             if err != nil {
@@ -24,10 +28,10 @@
 //                     errorLog.Fatalln("Can't listen on UDP")
 //             }
 //             defer udpListener.Close()
-//             p := crosscoap.COAPProxy{
+//             p := crosscoap.Proxy{
 //                     Listener:   udpListener,
 //                     BackendURL: "http://127.0.0.1:8000/",
-//                     Timeout:    10 * time.Second,
+//                     Timeout:    &timeout,
 //                     AccessLog:  appLog,
 //                     ErrorLog:   appLog,
 //             }


### PR DESCRIPTION
The example implementation included for using `crosscoap` as a library does not work. This pull request serves to correct the documentation both in `crosscoap.go` and the README.