### PR TITLE
Set value of URIHost as Host in outgoing HTTP request

### DIFF
--- a/crosscoap_test.go
+++ b/crosscoap_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestProxyWithConfirmableRequest(t *testing.T) {
+	const customUriHost = "hocus-pocus.example.com"
 	const backendResponse = "<body>This is the response text</body>"
 	const backendStatus = 404
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -25,6 +26,9 @@ func TestProxyWithConfirmableRequest(t *testing.T) {
 		}
 		if r.UserAgent() != "crosscoap/1.0" {
 			t.Errorf("backend got unexpected User-Agent: %v", r.UserAgent())
+		}
+		if r.Host != customUriHost {
+			t.Errorf("backend got unexpected Host: %v", r.Host)
 		}
 		//if r.Header.Get("X-Forwarded-For") == "" {
 		//	t.Errorf("didn't get X-Forwarded-For header")
@@ -48,6 +52,7 @@ func TestProxyWithConfirmableRequest(t *testing.T) {
 	}
 	req.SetPathString("/some/path")
 	req.SetOption(coap.ContentFormat, coap.AppJSON)
+	req.SetOption(coap.URIHost, customUriHost)
 
 	c, err := coap.Dial("udp", crosscoapAddr)
 	if err != nil {

--- a/translate.go
+++ b/translate.go
@@ -118,6 +118,10 @@ func translateCOAPRequestToHTTPRequest(coapMsg *coap.Message, backendURLPrefix s
 		return nil
 	}
 
+	if s, ok := coapMsg.Option(coap.URIHost).(string); ok {
+		req.Host = s
+	}
+
 	contentType := getHTTPContentTypeFromCOAPMessage(*coapMsg)
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)

--- a/translate_test.go
+++ b/translate_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -86,6 +87,41 @@ func TestTranslateCOAPRequestWithBadURI(t *testing.T) {
 	httpReq := translateCOAPRequestToHTTPRequest(&coapMsg, "http://localhost:9876/backend2/")
 	if httpReq != nil {
 		t.Errorf("httpReq is not nil")
+	}
+}
+
+func TestTranslateCOAPRequestWithUriHost(t *testing.T) {
+	customUriHost := "hocus-pocus.example.com"
+	coapMsg := coap.Message{
+		Type:      coap.Confirmable,
+		Code:      coap.GET,
+		MessageID: 1234,
+	}
+	coapMsg.SetPathString("resource")
+	coapMsg.SetOption(coap.URIHost, []string{customUriHost})
+
+	httpReq := translateCOAPRequestToHTTPRequest(&coapMsg, "http://localhost:9876/backend2/")
+	if httpReq.Host != customUriHost {
+		t.Errorf("httpReq.Host is '%v'", httpReq.Host)
+	}
+}
+
+func TestTranslateCOAPRequestWithoutUriHost(t *testing.T) {
+	backendURLPrefix := "http://localhost:9876/backend2/"
+	coapMsg := coap.Message{
+		Type:      coap.Confirmable,
+		Code:      coap.GET,
+		MessageID: 1234,
+	}
+	coapMsg.SetPathString("resource")
+
+	httpReq := translateCOAPRequestToHTTPRequest(&coapMsg, backendURLPrefix)
+	u, err := url.Parse(backendURLPrefix)
+	if err != nil {
+		t.Error("error parsing URL")
+	}
+	if httpReq.Host != u.Host {
+		t.Errorf("httpReq.Host is '%v'", httpReq.Host)
 	}
 }
 


### PR DESCRIPTION
This pull request changes behavior of crosscoap so that value of option `coap.URIHost` gets assigned to outgoing `*http.Request`. This change allows to run crosscoap as a single instance while being able to forward requests to multiple backends.