### PR TITLE
Support application/json compressed with deflate algorithm

### DIFF
--- a/translate.go
+++ b/translate.go
@@ -21,6 +21,8 @@ type content struct {
 	Encoding string
 }
 
+const appJSONDeflate coap.MediaType = 11050
+
 var coapContentFormatContentType = map[coap.MediaType]content{
 	coap.TextPlain:     content{Type: "text/plain;charset=utf-8"},
 	coap.AppLinkFormat: content{Type: "application/link-format"},
@@ -28,6 +30,7 @@ var coapContentFormatContentType = map[coap.MediaType]content{
 	coap.AppOctets:     content{Type: "application/octet-stream"},
 	coap.AppExi:        content{Type: "application/exi"},
 	coap.AppJSON:       content{Type: "application/json"},
+	appJSONDeflate:     content{Type: "application/json", Encoding: "deflate"},
 }
 
 var httpStatusCOAPCode = map[int]coap.COAPCode{


### PR DESCRIPTION
This PR does two things.

1. It changes how CoAP ContentFormat is translated in crosscoap. The change is required because right now, it's impossible to add new ContentFormat that shares HTTP ContentType (i.e. "application/json") with an already existing item. This change also allows to specify Encoding, when defined, the value is transfered in HTTP request via `Content-Encoding`.

2. It adds support for application/json compressed with deflate algorithm. Value of this ContentFormat is already registered with IANA[0]. This addition makes use of the previous change.

[0] https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats